### PR TITLE
Witch Forest Update: Debug Menu is now full height by default

### DIFF
--- a/HigherSidebar/Mod.cs
+++ b/HigherSidebar/Mod.cs
@@ -14,7 +14,6 @@ namespace HigherSidebar {
         private static Harmony harmony;
 
         private static ConfigEntry<float> infoBoxHeight;
-        private static ConfigEntry<float> debugMenuHeight;
 
         private void Awake() {
             harmony = new Harmony(GUID);
@@ -23,15 +22,11 @@ namespace HigherSidebar {
             // 200 is vanilla
             infoBoxHeight = Config.Bind("UI", "Info Box Height", 400f, "Height of the info box. Vanilla is 200");
             infoBoxHeight.SettingChanged += (_1, _2) => UpdateSidebarHeights();
-
-            debugMenuHeight = Config.Bind("UI", "Debug Menu Height", 990f, "Height of the debug menu. Vanilla is 280");
-            debugMenuHeight.SettingChanged += (_1, _2) => UpdateDebugHeight();
         }
 
         [HarmonyPatch(typeof(GameScreen), nameof(GameScreen.Awake)), HarmonyPostfix]
         private static void AfterGameScreenAwake() {
             UpdateSidebarHeights();
-            UpdateDebugHeight();
         }
 
         private static void UpdateSidebarHeights()
@@ -50,18 +45,6 @@ namespace HigherSidebar {
             sizeDelta = GameScreen.instance.SideTransform.sizeDelta;
             sizeDelta.y = - infoBoxHeight.Value - 15;
             GameScreen.instance.SideTransform.sizeDelta = sizeDelta;
-        }
-
-        private static void UpdateDebugHeight()
-        {
-            if (!GameScreen.instance) {
-                return;
-            }
-
-            RectTransform debugScreen = GameScreen.instance.DebugScreen.rectTransform;
-            Vector2 sizeDelta = debugScreen.sizeDelta;
-            sizeDelta.y = debugMenuHeight.Value;
-            debugScreen.sizeDelta = sizeDelta;
         }
     }
 }


### PR DESCRIPTION
So adding any more height breaks the menu.

Actually, maybe this code could be used to reduce it now? Haven't tried it but not sure it makes much sense.